### PR TITLE
Fix repo name to avoid layman warning

### DIFF
--- a/profiles/repo_name
+++ b/profiles/repo_name
@@ -1,1 +1,1 @@
-Darling overlay
+darling-overlay


### PR DESCRIPTION
> !!! Section 'darling-overlay' in repos.conf has name different from repository name 'Darling-overlay' set inside repository